### PR TITLE
downgrade TypeScript

### DIFF
--- a/.yarn/versions/9806bd15.yml
+++ b/.yarn/versions/9806bd15.yml
@@ -1,0 +1,2 @@
+releases:
+  ts-overrides-plugin: patch

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -20,7 +20,7 @@
     "ts-node": "^10.9.2",
     "ts-overrides-plugin": "workspce:*",
     "ts-patch": "3.2.0",
-    "typescript": "5.5.2",
+    "typescript": "5.5.1-rc",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"
   },

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -22,6 +22,7 @@ any other cases where you need to override the `tsconfig` settings for specific 
 
 - Paths in `tsconfig` should not start with `./`
 - The plugin does not work in `WebStorm` when using `yarn pnp`
+- The plugin does not work with TypeScript `>5.5.2` because of the `ts-patch` library [issue](https://github.com/nonara/ts-patch/issues/159)
 - Some issues may be caused by incompatibility of the latest TypeScript version with ts-patch. For example: [issue](https://github.com/nonara/ts-patch/issues/152), [issue](https://github.com/nonara/ts-patch/issues/140), [issue](https://github.com/nonara/ts-patch/issues/159)
 - Memory leaks are possible with a very large number of files (> 3000)
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -40,7 +40,7 @@
 		"eslint": "8.57.0",
 		"eslint-config-fuks": "^2.0.0",
 		"ts-patch": "3.2.0",
-		"typescript": "5.5.2"
+		"typescript": "5.5.1-rc"
 	},
 	"peerDependencies": {
 		"ts-patch": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,7 +3921,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     ts-overrides-plugin: "workspce:*"
     ts-patch: "npm:3.2.0"
-    typescript: "npm:5.5.2"
+    typescript: "npm:5.5.1-rc"
     webpack: "npm:^5.89.0"
     webpack-cli: "npm:^5.1.4"
   languageName: unknown
@@ -6727,7 +6727,7 @@ __metadata:
     eslint-config-fuks: "npm:^2.0.0"
     outmatch: "npm:^1.0.0"
     ts-patch: "npm:3.2.0"
-    typescript: "npm:5.5.2"
+    typescript: "npm:5.5.1-rc"
   peerDependencies:
     ts-patch: ^3.0.0
     typescript: ^5.0.0
@@ -6856,23 +6856,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.5.2":
-  version: 5.5.2
-  resolution: "typescript@npm:5.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypescript%2F-%2Ftypescript-5.5.2.tgz"
+"typescript@npm:5.5.1-rc":
+  version: 5.5.1-rc
+  resolution: "typescript@npm:5.5.1-rc::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftypescript%2F-%2Ftypescript-5.5.1-rc.tgz"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/8ca39b27b5f9bd7f32db795045933ab5247897660627251e8254180b792a395bf061ea7231947d5d7ffa5cb4cc771970fd4ef543275f9b559f08c9325cccfce3
+  checksum: 10c0/c098e0a2c90472003bf5e4cb9548f2298beb7930cfdf65d529a7ca6e688bbf5ee77d00184a9de18921e13022000120740ff56fb109976d09eb4c5202b4cd343b
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>":
-  version: 5.5.2
-  resolution: "typescript@patch:typescript@npm%3A5.5.2%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-5.5.2.tgz#optional!builtin<compat/typescript>::version=5.5.2&hash=b45daf"
+"typescript@patch:typescript@npm%3A5.5.1-rc#optional!builtin<compat/typescript>":
+  version: 5.5.1-rc
+  resolution: "typescript@patch:typescript@npm%3A5.5.1-rc%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-5.5.1-rc.tgz#optional!builtin<compat/typescript>::version=5.5.1-rc&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6721ac8933a70c252d7b640b345792e103d881811ff660355617c1836526dbb71c2044e2e77a8823fb3570b469f33276875a4cab6d3c4de4ae7d7ee1c3074ae4
+  checksum: 10c0/2bdee8341050466230dfd9c2202981062bbf50644d40452e8d164b5e8daa85a53bffc60ebca21d3d984fe2b752c63fcca33a7ddac67acf0d609ccab5b34847e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Downgrade TypeScript, add info about incompatibility of the TypeScript 5.5.2 https://github.com/nonara/ts-patch/issues/159