### PR TITLE
Add bugs metadata to package manifest

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,6 +3,9 @@
 	"version": "0.4.3",
 	"repository": "git@github.com:DiFuks/ts-overrides-plugin.git",
 	"homepage": "https://github.com/DiFuks/ts-overrides-plugin",
+	  "bugs": {
+		      "url": "https://github.com/DiFuks/ts-overrides-plugin/issues"
+	  },
 	"description": "TypeScript plugin for overriding config for folders",
 	"keywords": [
 		"typescript",


### PR DESCRIPTION
Adds the public GitHub issues URL to the package metadata so npm consumers can find the issue tracker from the published package.

This is metadata-only and does not change runtime code.